### PR TITLE
remove jest-specific config

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -15,8 +15,6 @@ interface EnabledAbq {
   host: string
   port: number
   shouldGenerateManifest: boolean
-  shouldHideNativeOutput: boolean
-  shouldRunIndividualTests: boolean
 }
 
 interface DisabledAbq {
@@ -25,8 +23,6 @@ interface DisabledAbq {
   host: undefined
   port: undefined
   shouldGenerateManifest: false
-  shouldHideNativeOutput: false
-  shouldRunIndividualTests: false
 }
 
 export type AbqConfiguration = EnabledAbq | DisabledAbq
@@ -39,9 +35,7 @@ if (host && typeof port !== 'undefined') {
     experiments: {},
     host,
     port,
-    shouldGenerateManifest: !!process.env.ABQ_GENERATE_MANIFEST,
-    shouldHideNativeOutput: !!process.env.ABQ_HIDE_NATIVE_OUTPUT,
-    shouldRunIndividualTests: !!process.env.ABQ_RUN_INDIVIDUAL_TESTS
+    shouldGenerateManifest: !!process.env.ABQ_GENERATE_MANIFEST
   } as EnabledAbq
 } else {
   abq = {
@@ -49,9 +43,7 @@ if (host && typeof port !== 'undefined') {
     experiments: {},
     host: undefined,
     port: undefined,
-    shouldGenerateManifest: false,
-    shouldHideNativeOutput: false,
-    shouldRunIndividualTests: false
+    shouldGenerateManifest: false
   } as DisabledAbq
 }
 


### PR DESCRIPTION
these options are jest-specific so they don't belong in `abq-js`