### PR TITLE
expose AbqConfiguration and make adapter version configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,8 @@ jobs:
           cache: npm
       - name: Install npm dependencies
         run: npm ci
-      - name: Build
-        run: npm run build
-      - name: Lint
-        run: npm run lint:check
+      - name: Run tests
+        run: npm test
   actionlint:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "format": "eslint --fix --ext .js,.ts src",
     "lint:check": "eslint --ext .js,.ts src",
-    "test": "npm run lint:check",
+    "test": "npm run build && npm run lint:check",
     "prepack": "npm run build",
     "prepublishOnly": "npm test"
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,6 +1,4 @@
 // package.json is outside of TypeScript rootDir.
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-export const { version: VERSION } = require('../package.json')
 
 const abqSocket = process.env.ABQ_SOCKET
 let host, portString, port

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { getAbqConfiguration } from './configuration'
+export { getAbqConfiguration, AbqConfiguration } from './configuration'
 export {
   initSuccessMessage,
   protocolReader,

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -68,6 +68,7 @@ const CURRENT_PROTOCOL_VERSION_MINOR = 1
 
 interface SpawnedMessageInterface {
   adapterName: string
+  adapterVersion: string
   testFramework: string
   testFrameworkVersion: string
 }

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,6 +1,5 @@
 import { Readable, Writable } from 'stream'
 import * as AbqTypes from './types'
-import { VERSION } from './configuration'
 
 /*
  * Communication between abq TCP sockets the following protocol:
@@ -72,7 +71,7 @@ interface SpawnedMessageInterface {
   testFramework: string
   testFrameworkVersion: string
 }
-export function spawnedMessage({ adapterName, testFramework, testFrameworkVersion }: SpawnedMessageInterface): AbqTypes.AbqNativeRunnerSpawnedMessage {
+export function spawnedMessage({ adapterName, adapterVersion, testFramework, testFrameworkVersion }: SpawnedMessageInterface): AbqTypes.AbqNativeRunnerSpawnedMessage {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const protocol_version: AbqTypes.ProtocolVersion = {
     type: 'abq_protocol_version',
@@ -84,7 +83,7 @@ export function spawnedMessage({ adapterName, testFramework, testFrameworkVersio
   const runner_specification: AbqTypes.NativeRunnerSpecification = {
     type: 'abq_native_runner_specification',
     name: adapterName,
-    version: VERSION,
+    version: adapterVersion,
     test_framework: testFramework,
     test_framework_version: testFrameworkVersion,
     language: 'javascript',


### PR DESCRIPTION
- expose AbqConfiguration
- don't expose abq-js version, enforce pulling in library version instead
