### PR TITLE
test case message should also be generic

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -25,10 +25,7 @@ export interface ManifestMessage {
 export interface TestCaseMessage {
   test_case: {
     id: string
-    meta: {
-      fileName: string
-      testName?: string
-    }
+    meta: Record<string, any>
   }
 }
 


### PR DESCRIPTION
follow-up to https://github.com/rwx-research/abq-js/pull/5

now that meta is generic, test case message should also be generic.

we should pass in the meta type from the test runner (as the manifest & test cases should match). Might do this in another followup PR but I'm not quite so fluent in typescript yet