### PR TITLE
TestResultError type should be 'error'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rwx-research/abq",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rwx-research/abq",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-alpha.4",
       "license": "ISC",
       "devDependencies": {
         "@types/node": "^18.11.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rwx-research/abq",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/rwx-research/abq-js.git"

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,7 @@ export interface TestResultFailure {
 }
 
 export interface TestResultError {
-  type: 'failure'
+  type: 'error'
   exception?: string
   backtrace?: string[]
 }


### PR DESCRIPTION
`TestResultError.type` should be `'error'`, while `TestResultFailure.type` remains `'failure'`.

[Native Runner Protocol 0.2 RFC](https://www.notion.so/rwx/Native-Runner-Protocol-0-2-d992ef3b4fde4289b02244c1b89a8cc7#a19ecc7fac514512a8ad1d8a18eba765)