### PR TITLE
Use number instead of bigint to back nanoseconds.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rwx-research/abq",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rwx-research/abq",
-      "version": "0.1.0-alpha.4",
+      "version": "0.1.0-alpha.5",
       "license": "ISC",
       "devDependencies": {
         "@types/node": "^18.11.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rwx-research/abq",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/rwx-research/abq-js.git"

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export interface TestCaseMessage {
   }
 }
 
-export type Nanoseconds = bigint
+export type Nanoseconds = number
 
 export interface TestResultFailure {
   type: 'failure'


### PR DESCRIPTION
`BigInt` does not serialize via `JSON.stringify`. The workarounds to serialize involve serializing it as a string, which won't work for ABQ.

Instead, we'll use `number`, which gives us (2^53 - 1) integer space, enough for tests that take about 100 days to run.