### PR TITLE
Expose Location in 0.1.0-alpha.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rwx-research/abq",
-  "version": "0.1.0-alpha.6",
+  "version": "0.1.0-alpha.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/rwx-research/abq-js.git"
@@ -15,7 +15,6 @@
     "test": "npm run build && npm run lint:check",
     "prepack": "npm run build",
     "prepublishOnly": "npm test"
-
   },
   "devDependencies": {
     "@types/node": "^18.11.15",

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,14 @@ export type TestResultStatus =
   | { type: 'todo' }
   | { type: 'timed_out' }
 
+export interface Location {
+  file: string
+  /** A 1-indexed line number. */
+  line?: number
+  /** A 1-indexed column number. */
+  column?: number
+}
+
 export interface TestResult {
   status: TestResultStatus
   // An opaque ID of the test for use by a native test runner


### PR DESCRIPTION
Previously, the `Location` type was not exposed by the protocol here. This type-checked correctly because a `Location` in the TS DOM standard library was resolved.