### PR TITLE
Incremental test result messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rwx-research/abq",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rwx-research/abq",
-      "version": "0.1.0-alpha.9",
+      "version": "0.1.0-alpha.10",
       "license": "ISC",
       "devDependencies": {
         "@types/node": "^18.11.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rwx-research/abq",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/rwx-research/abq-js.git"

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -1,10 +1,11 @@
 import { Socket } from 'net'
 import { AbqConfiguration } from './configuration'
 import { protocolWrite, spawnedMessage, SpawnedMessageInterface } from './protocol'
+import type { Connection } from './types'
 
 export async function connect(
   abqConfig: AbqConfiguration,
-  { adapterName, adapterVersion, testFramework, testFrameworkVersion }: SpawnedMessageInterface): Promise<Socket> {
+  { adapterName, adapterVersion, testFramework, testFrameworkVersion }: SpawnedMessageInterface): Promise<Connection> {
   if (!abqConfig.enabled) {
     throw new Error('abq must be enabled to connect')
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,7 +133,7 @@ export interface IncrementalTestResultStep {
 
 export interface IncrementalTestResultDone {
   type: 'incremental_result_done'
-  last_test_result: TestResult
+  last_test_result?: TestResult
 }
 
 export interface NativeRunnerSpecification {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,7 @@
+import type * as net from 'net'
+
+export type Connection = net.Socket
+
 export interface Test {
   type: 'test'
   id: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,7 +109,10 @@ export interface OutOfBandError {
   meta?: Record<string, any>
 }
 
-export type TestResultMessage = SingleTestResultMessage | MultipleTestResultsMessage
+export type TestResultMessage =
+  | SingleTestResultMessage
+  | MultipleTestResultsMessage
+  | IncrementalTestResultMessage
 
 export interface SingleTestResultMessage {
   test_result: TestResult
@@ -117,6 +120,20 @@ export interface SingleTestResultMessage {
 
 export interface MultipleTestResultsMessage {
   test_results: TestResult[]
+}
+
+export type IncrementalTestResultMessage =
+  | IncrementalTestResultStep
+  | IncrementalTestResultDone
+
+export interface IncrementalTestResultStep {
+  type: 'incremental_result'
+  one_test_result: TestResult
+}
+
+export interface IncrementalTestResultDone {
+  type: 'incremental_result_done'
+  last_test_result: TestResult
 }
 
 export interface NativeRunnerSpecification {
@@ -148,5 +165,4 @@ export interface InitMessage {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface InitSuccessMessage {
-}
+export interface InitSuccessMessage {}


### PR DESCRIPTION
An addendum to the 0.2 protocol we may want to support if we choose to
go down the route of https://github.com/rwx-research/jest/pull/18.
